### PR TITLE
バグ対応

### DIFF
--- a/Assets/Haruma/SoundScripts/BGMplayer.cs
+++ b/Assets/Haruma/SoundScripts/BGMplayer.cs
@@ -29,6 +29,7 @@ public class BGMplayer : MonoBehaviour
         if (ActiveSceneManager.S_Title == true)
         {
             playerController.BGMStop();
+            playerController.Stop();
             playerController.SetAcb(atomLoader.acbAssets[0].Handle);
             playerController.SetCueName("Title_BGM");
             playerController.BGMPlay();


### PR DESCRIPTION
ウナギが多重再生＆再生停止しない
カジキがならないシーンがある
上二つは、スクリプトが頻繁に変更されてので安定するまで放置

現在スキルの仕様に左クリックを使用しており、銛による攻撃と操作が被っているため音が多重再生されてしまう。
また、鳴らしすぎると何故かBGMが止まる。

とりあえず、EEがずっと鳴ってるのうるさいのでスタート画面に戻ったら再生停止する
BGMplayer.csに変更↓
```
～～～
    void Update()
    {
        if (ActiveSceneManager.S_Title == true)
        {
            playerController.BGMStop();
            playerController.Stop();
            playerController.SetAcb(atomLoader.acbAssets[0].Handle);
            playerController.SetCueName("Title_BGM");
            playerController.BGMPlay();
            ActiveSceneManager.S_Title = false;
        }
～～～
        }
～～～
```