### PR TITLE
BGMと一部MenuSFXの不具合修正

### DIFF
--- a/Assets/Haruma/SoundScripts/BGMplayer.cs
+++ b/Assets/Haruma/SoundScripts/BGMplayer.cs
@@ -25,12 +25,13 @@ public class BGMplayer : MonoBehaviour
     void Update(){
         /*
         if (ActiveSceneManager.S_Title == true){
+            //BGMや効果音の停止
             playerController.Stop();
-            playerController.SetAcb(atomLoader.acbAssets[2].Handle);
-            playerController.SetCueName("bubble");
-            playerController.BGMPlay();
-            
-        ActiveSceneManager.S_Title = false;
+            playerController.BGMStop();
+            playerController.KurageStop();
+            playerController.EEStop();
+
+            ActiveSceneManager.S_Title = false;
         }
         */
         if (ActiveSceneManager.S_Tutorial == true){

--- a/Assets/Haruma/SoundScripts/PlayerController.cs
+++ b/Assets/Haruma/SoundScripts/PlayerController.cs
@@ -19,6 +19,7 @@ public class PlayerController : MonoBehaviour
     private CriAtomExPlayback Kurageplayback;
     private CriAtomExPlayback EEplayback;
     private CriAtomExPlayback BGMplayback;
+    private CriAtomExPlayback MenuSFXplayback;
 
     /*ACB 情報 */
     private CriAtomExAcb acb;
@@ -82,6 +83,11 @@ public class PlayerController : MonoBehaviour
         anyPlayer.SetCue(acb, cueName);
         BGMplayback = anyPlayer.Start();
     }
+    //メニューSFX用プレイバック
+    public void MenuSFXPlay(){
+        anyPlayer.SetCue(acb, cueName);
+        MenuSFXplayback = anyPlayer.Start();
+    }
 
     /*プレーヤーの停止 */
     public void Stop(){
@@ -94,9 +100,11 @@ public class PlayerController : MonoBehaviour
     public void EEStop(){
         EEplayback.Stop();
     }
-    public void BGMStop()
-    {
+    public void BGMStop(){
         BGMplayback.Stop();
+    }
+    public void MenuSFXStop(){
+        MenuSFXplayback.Stop();
     }
 
     /*プレーヤーの一時停止 */

--- a/Assets/Haruma/SoundScripts/SFXplayer.cs
+++ b/Assets/Haruma/SoundScripts/SFXplayer.cs
@@ -32,27 +32,25 @@ public class SFXplayer : MonoBehaviour
         if (GameStart.menu_Sound == 1){
             playerController.SetAcb(atomLoader.acbAssets[2].Handle);
             playerController.SetCueName("menu_Confirm");
-            playerController.Play();
+            playerController.MenuSFXPlay();
             GameStart.menu_Sound = 0;
         }
         if (GameStart.menu_Sound == 2){
             playerController.SetAcb(atomLoader.acbAssets[2].Handle);
             playerController.SetCueName("menu_Back");
-            playerController.Play();
+            playerController.MenuSFXPlay();
             GameStart.menu_Sound = 0;
         }
-        if (GameStart.menu_Sound == 3)
-        {
+        if (GameStart.menu_Sound == 3){
             playerController.SetAcb(atomLoader.acbAssets[2].Handle);
             playerController.SetCueName("menu_Selecting");
-            playerController.Play();
+            playerController.MenuSFXPlay();
             GameStart.menu_Sound = 0;
         }
-        if (GameStart.menu_Sound == 4)
-        {
+        if (GameStart.menu_Sound == 4){
             playerController.SetAcb(atomLoader.acbAssets[1].Handle);
             playerController.SetCueName("Start_JINGLE");
-            playerController.Play();
+            playerController.MenuSFXPlay();
             GameStart.menu_Sound = 0;
         }
         //ラジオ
@@ -155,10 +153,11 @@ public class SFXplayer : MonoBehaviour
         //泡音用コルーチンスタート
         if (ActiveSceneManager.S_Title == true || ActiveSceneManager.S_StageSelect == true)
         {
-            playerController.Stop();
+            //BGMや効果音の停止
             playerController.BGMStop();
             playerController.KurageStop();
             playerController.EEStop();
+
             StartCoroutine(bubbleRondomize());
             ActiveSceneManager.S_Title = false;
             ActiveSceneManager.S_StageSelect = false;
@@ -211,7 +210,7 @@ public class SFXplayer : MonoBehaviour
     private void bubble_Play(){
         playerController.SetAcb(atomLoader.acbAssets[2].Handle);
         playerController.SetCueName("bubble");
-        playerController.BGMPlay();
+        playerController.MenuSFXPlay();
         Debug.Log("bubble Playing");
     }
 }

--- a/Assets/Scenes/Scene1_Start.unity
+++ b/Assets/Scenes/Scene1_Start.unity
@@ -281,7 +281,7 @@ MonoBehaviour:
   m_Text: '<size=55>Directer/Producer/Scenario Writer</size>
 
     <color=red>Nakamura
-    Gouki</color>
+    Koki</color>
 
 '
 --- !u!222 &150349318
@@ -2709,7 +2709,7 @@ MonoBehaviour:
     m_LineSpacing: 1
   m_Text: '<size=55>UI Designer</size>
 
-    <color=red>Nakamura Gouki</color>
+    <color=red>Nakamura Koki</color>
 
     <color=aqua>Nagayama
     Reon</color>'


### PR DESCRIPTION
SFXplayer.cs
```
～～～
        if (GameStart.menu_Sound == 1){
～～～
            playerController.MenuSFXPlay();
～～～
        }
        if (GameStart.menu_Sound == 2){
～～～
            playerController.MenuSFXPlay();
～～～
        }
        if (GameStart.menu_Sound == 3){
～～～
            playerController.MenuSFXPlay();
～～～
        }
        if (GameStart.menu_Sound == 4){
～～～
            playerController.MenuSFXPlay();
～～～
        }
～～～
        //泡音用コルーチンスタート
        if (ActiveSceneManager.S_Title == true || ActiveSceneManager.S_StageSelect == true)
        {
            //BGMや効果音の停止
            playerController.BGMStop();
            playerController.KurageStop();
            playerController.EEStop();

            StartCoroutine(bubbleRondomize());
            ActiveSceneManager.S_Title = false;
            ActiveSceneManager.S_StageSelect = false;
            Debug.Log("Coroutine Start");
        }
～～～
```

PlayerController.cs
```
～～～
    private CriAtomExPlayback MenuSFXplayback;
～～～
    //メニューSFX用プレイバック
    public void MenuSFXPlay(){
        anyPlayer.SetCue(acb, cueName);
        MenuSFXplayback = anyPlayer.Start();
    }
～～～
    public void MenuSFXStop(){
        MenuSFXplayback.Stop();
    }
～～～
```

BGMplayer.cs
```
～～～
        /*
        if (ActiveSceneManager.S_Title == true){
            //BGMや効果音の停止
            playerController.Stop();
            playerController.BGMStop();
            playerController.KurageStop();
            playerController.EEStop();

            ActiveSceneManager.S_Title = false;
        }
        */
～～～
```